### PR TITLE
Fix / Add support for Android API level 34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## ChangeLog
 
+#### Version 0.8.1
+- Add support for Android API level 34
+
 #### Version 0.8.0
 - Set PendingIntent mutability (fixes #45)
 - Depend on cordova-androidx-build to automatically work with AndroidX

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## ChangeLog
+
+#### Version 0.8.0
+- Set PendingIntent mutability (fixes #45)
+- Depend on cordova-androidx-build to automatically work with AndroidX
+
 #### Version 0.7.3 (not yet released)
 - Check if screen is off on Android
 - Wake-up device on Android

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-background-mode",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Prevent apps from going to sleep in background.",
   "cordova": {
     "id": "cordova-plugin-background-mode",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-background-mode",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "description": "Prevent apps from going to sleep in background.",
   "cordova": {
     "id": "cordova-plugin-background-mode",

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-background-mode"
-        version="0.8.0">
+        version="0.8.1">
 
     <name>BackgroundMode</name>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -71,12 +71,13 @@
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
-            <service android:name="de.appplant.cordova.plugin.background.ForegroundService" />
+            <service android:name="de.appplant.cordova.plugin.background.ForegroundService" android:foregroundServiceType="mediaPlayback" />
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/manifest">
             <uses-permission android:name="android.permission.WAKE_LOCK" />
 			<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+            <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
             <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
             <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
         </config-file>

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-background-mode"
-        version="0.7.3">
+        version="0.8.0">
 
     <name>BackgroundMode</name>
 
@@ -94,6 +94,7 @@
             target-dir="src/de/appplant/cordova/plugin/background" />
 
         <framework src="androidx.core:core:1.0.0" />
+		<dependency id="cordova-androidx-build" />
         <resource-file src="src/android/res/drawable/power.xml" target="res/drawable/power.xml" />
         <resource-file src="src/android/res/drawable-hdpi/power.png" target="res/drawable-hdpi/power.png" />
         <resource-file src="src/android/res/drawable-mdpi/power.png" target="res/drawable-mdpi/power.png" />

--- a/src/android/BackgroundMode.java
+++ b/src/android/BackgroundMode.java
@@ -25,6 +25,7 @@ import android.app.Activity;
 import android.content.*;
 import android.os.Bundle;
 import android.os.IBinder;
+import android.os.Build;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaInterface;
@@ -83,7 +84,11 @@ public class BackgroundMode extends CordovaPlugin {
         super.initialize(cordova, webView);
         IntentFilter filter = new IntentFilter();
         filter.addAction("com.backgroundmode.close" + cordova.getContext().getPackageName());
-        cordova.getActivity().registerReceiver(receiver, filter);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            cordova.getActivity().registerReceiver(receiver, filter, Context.RECEIVER_EXPORTED);
+        } else {
+            cordova.getActivity().registerReceiver(receiver, filter);
+        }
 
     }
 

--- a/src/android/ForegroundService.java
+++ b/src/android/ForegroundService.java
@@ -215,7 +215,7 @@ public class ForegroundService extends Service {
         if (settings.optBoolean("allowClose", false)) {
 
             final Intent clostAppIntent = new Intent("com.backgroundmode.close" + pkgName);
-            final PendingIntent closeIntent = PendingIntent.getBroadcast(context, 1337, clostAppIntent, 0);
+            final PendingIntent closeIntent = PendingIntent.getBroadcast(context, 1337, clostAppIntent, PendingIntent.FLAG_IMMUTABLE);
             final String closeIconName = settings.optString("closeIcon", "power");
             NotificationCompat.Action.Builder closeAction = new NotificationCompat.Action.Builder(getIconResId(closeIconName), settings.optString("closeTitle", "Close"), closeIntent);
             notification.addAction(closeAction.build());
@@ -240,7 +240,7 @@ public class ForegroundService extends Service {
             intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
             PendingIntent contentIntent = PendingIntent.getActivity(
                     context, NOTIFICATION_ID, intent,
-                    PendingIntent.FLAG_UPDATE_CURRENT);
+                    PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
 
             notification.setContentIntent(contentIntent);

--- a/src/android/ForegroundService.java
+++ b/src/android/ForegroundService.java
@@ -126,7 +126,11 @@ public class ForegroundService extends Service {
         boolean isSilent    = settings.optBoolean("silent", false);
 
         if (!isSilent) {
-            startForeground(NOTIFICATION_ID, makeNotification());
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                startForeground(NOTIFICATION_ID, makeNotification(), FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK);
+            } else {
+                startForeground(NOTIFICATION_ID, makeNotification());
+            }
         }
 
         PowerManager pm = (PowerManager)getSystemService(POWER_SERVICE);


### PR DESCRIPTION
Changes:
- Synced this fork with [TheBosZ/cordova-plugin-run-in-background](https://bitbucket.org/TheBosZ/cordova-plugin-run-in-background) - which fixes a [issue in API level 30+](https://stackoverflow.com/questions/67045607/how-to-resolve-missing-pendingintent-mutability-flag-lint-warning-in-android-a)
- Add support for Android API level 34 regarding a `RECEIVER_EXPORTED` error and crash when `startForeground` is called